### PR TITLE
docs: Correct prog_models URL

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -191,7 +191,7 @@ author={
     month     = December,
     year      = 2022,
     version   = {1.4},
-    url       = {https://github.com/nasa/prog\_models}
+    url       = {https://github.com/nasa/prog_models}
     }
 
   @article{christ2018time,


### PR DESCRIPTION
* Correct URL to avoid trying to escape underscore so render in paper will be correct.
   - c.f. https://github.com/nasa/prog_models

@lucianolorenti I'm opening this PR as the _final_ URL in your paper has a broken URL because of it (sorry!). In your defense, you followed the instructions from https://github.com/nasa/prog_models/blob/7bdd6d6996d2af0b9b45e5766906194faceaa3b0/README.md#citing-this-repository and did exactly as they ask. It just seems that this fails the render for the paper on JOSS though.